### PR TITLE
Change makefile to run properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,11 @@ update:
 install:
 	pip install git+https://github.com/teampopong/popong-models.git
 	pip install git+https://github.com/teampopong/popong-data-utils.git
-	cd /tmp
-	git clone git@github.com:teampopong/popong-nlp.git
-	cd popong-nlp
-	git submodule init
-	git submodule update
-	sudo python setup.py install
+	cd /tmp && git clone git@github.com:teampopong/popong-nlp.git
+
+	cd /tmp/popong-nlp && git submodule init
+	cd /tmp/popong-nlp && git submodule update
+	cd /tmp/popong-nlp && sudo python setup.py install
 
 extract_i18n:
 	pybabel extract -F babel.cfg -k ngettext -k lazy_gettext -o pokr/messages.pot .


### PR DESCRIPTION
제 로컬 환경의 문제...인지는 모르겠으나 makefile의 ```make install```이 제대로 실행되지 않아 (스크랩트의 의도대로 동작하지 않는 것 같아) 약간 수정을 해봤습니다.

문제는 /tmp에 popong-nlp를 clone하고 setup.py를 실행해야하는데, 
프로젝트 폴더 (pokr.kr)에 popong-nlp를 clone하고, pokr.kr에서 setup.py를 실행하려는 문제가 있었습니다.

이외에 ```make init``` 에서도 제대로 수행되었지만 에러가 나는 부분이 있는 것 같은데 우선 ```make install```이 되지 않는 부분부터 수정해봅니다. 